### PR TITLE
Filter null errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ module.exports.processors = {
             delete fileContents[fileName];
             var data = jshint.JSHINT.data();
             var errors = (data && data.errors) || [];
-            return errors.map(function(error) {
+            return errors.filter(function(e){ return !!e; }).map(function(error) {
                 return {
                     ruleId: "bad-json",
                     severity: 2,


### PR DESCRIPTION
I ran into an issue where jshint was adding a null value to the end of the error array. Filtering the falsey values out fixes the issue.