### PR TITLE
Support native eslint rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,14 +25,26 @@ module.exports.processors = {
     ".json": {
         preprocess: function(text, fileName) {
             fileContents[fileName] = text;
-            return [text];
+            var jsText = 'var json = ' + text;
+            return [jsText];
         },
         postprocess: function(messages, fileName) {
+            var eslintMessages = messages.length ? messages[0].filter(function(message) {
+                switch (message.ruleId) {
+                    case 'no-var': return message.source !== 'var json = {';
+                    case 'no-unused-vars': return message.source !== 'var json = {';
+                    case 'quotes': return message.message !== 'Strings must use singlequote.';
+                    case 'semi': return false;
+                    case 'comma-dangle': return false;
+                    default: return true;
+                }
+            }) : [];
+
             jshint.JSHINT(fileContents[fileName]);
             delete fileContents[fileName];
             var data = jshint.JSHINT.data();
             var errors = (data && data.errors) || [];
-            return errors.filter(function(e){ return !!e; }).map(function(error) {
+            var jshintMessages = errors.filter(function(e){ return !!e; }).map(function(error) {
                 return {
                     ruleId: "bad-json",
                     severity: 2,
@@ -42,6 +54,8 @@ module.exports.processors = {
                     column: error.character
                 };
             });
+
+            return eslintMessages.concat(jshintMessages);
         }
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -21,13 +21,14 @@ describe('plugin', function() {
     });
     describe('preprocess', function() {
         var preprocess = plugin.processors['.json'].preprocess;
-        it('should return the same text', function() {
+        it('should return the processable text', function() {
             var fileName = 'reallyLongFileName';
             var text = 'long long text';
+            var prefixedtext = 'var json = ' + text;
 
             var newText = preprocess(text, fileName);
             assert.isArray(newText, 'preprocess should return array');
-            assert.strictEqual(newText[0], text);
+            assert.strictEqual(newText[0], prefixedtext);
         });
     });
     describe('postprocess', function() {
@@ -49,6 +50,21 @@ describe('plugin', function() {
             fileName: 'trailingtext.json',
             text: '{ "my_string": "hello world" }' + ' \n' +  'bad_text'
         };
+
+        var ignorableMessages = [[
+            { ruleId: 'no-var', source: 'var json = {' },
+            { ruleId: 'no-unused-vars', source: 'var json = {' },
+            { ruleId: 'quotes', message: 'Strings must use singlequote.' },
+            { ruleId: 'semi' },
+            { ruleId: 'comma-dangle' }
+        ]];
+
+        var warnableMessages = [[
+            { ruleId: 'no-var', source: 'wrong' },
+            { ruleId: 'no-unused-vars', source: 'wrong' },
+            { ruleId: 'quotes', message: 'wrong' },
+            { ruleId: 'myrule' }
+        ]];
 
         var good = {
             fileName: 'good.json',
@@ -91,13 +107,13 @@ describe('plugin', function() {
         });
 
         it('should return multiple errors for multiple errors', function() {
-            var errors = postprocess([], multipleErrors.fileName);
+            var errors = postprocess(warnableMessages, multipleErrors.fileName);
             assert.isArray(errors, 'should return an array');
-            assert.lengthOf(errors, 2, 'should return one error');
+            assert.lengthOf(errors, 6, 'should return 6 errors');
         });
 
         it('should return no errors for good json', function() {
-            var errors = postprocess([], good.fileName);
+            var errors = postprocess(ignorableMessages, good.fileName);
             assert.isArray(errors, 'should return an array');
             assert.lengthOf(errors, 0, 'good json shouldnt have any errors');
         });


### PR DESCRIPTION
I took a stab at fixing #7.

By prefixing the content of a .json file with `var json = ` during preprocessing that content mimics regular Javascript, which can then be parsed by eslint as normal.

During postprocessing I ignore the messages introduced by our prefixing (`no-var`, `no-unused-vars` and `semi`) or aren't valid/relevant for .json files (`quotes` and `comma-dangle`), keeping only the real violations.

I left the jshint stuff in as I noticed it would find issues in .json files that eslint won't, so this gives an even richer linting result with both being used.

I added some testcases to the existing tests and changed a few to work with the new setup.