### PR TITLE
Fix ruleID to be a string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,7 +118,7 @@ module.exports.processors = {
             delete fileDocuments[fileName];
             var formattedErrors = errors.map(function(error) {
                 return {
-                    ruleId: error.code,
+                    ruleId: error.code.toString(),
                     severity: (error.severity == 1) ? 2 : 1,
                     message: error.message,
                     line: error.range.start.line + 1,

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,18 @@ var ErrorCode = {
     SchemaResolveError: 0x300
 };
 
+function getCodeRuleName(code) {
+    for (var codeName in ErrorCode) {
+        if (ErrorCode.hasOwnProperty(codeName)) {
+            if (ErrorCode[codeName] === code) {
+                return 'json/' + codeName.toLowerCase();
+            }
+        }
+    }
+
+    return 'json/unknown';
+}
+
 var fileContents = {};
 var fileDocuments = {};
 
@@ -76,7 +88,7 @@ var getDiagnostics = function(textDocument, jsonDocument) {
         }
     };
     var trailingCommaSeverity = 1; // ERROR
-    var commentSeverity = 1; // ERROR 
+    var commentSeverity = 1; // ERROR
 
     jsonDocument.syntaxErrors.forEach(function(p) {
         if (p.code === ErrorCode.TrailingComma) {
@@ -118,7 +130,7 @@ module.exports.processors = {
             delete fileDocuments[fileName];
             var formattedErrors = errors.map(function(error) {
                 return {
-                    ruleId: error.code.toString(),
+                    ruleId: getCodeRuleName(error.code),
                     severity: (error.severity == 1) ? 2 : 1,
                     message: error.message,
                     line: error.range.start.line + 1,
@@ -132,4 +144,3 @@ module.exports.processors = {
         }
     }
 };
-

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@ describe('plugin', function() {
             assert.lengthOf(errors, 1, 'should return one error');
 
             var error = errors[0];
-            assert.strictEqual(error.ruleId, '0', 'should have a string ID');
+            assert.strictEqual(error.ruleId, 'json/undefined', 'should have a string ID');
             assert.strictEqual(error.severity, 2, 'should have a numeric severity');
             assert.strictEqual(error.message, 'Property keys must be doublequoted', 'should have a message');
             assert.strictEqual(error.line, 1, 'should point to first line');
@@ -79,6 +79,7 @@ describe('plugin', function() {
             assert.lengthOf(errors, 1, 'should return one error');
 
             var error = errors[0];
+            assert.strictEqual(error.ruleId, 'json/trailingcomma', 'should have a string ID');
             assert.strictEqual(error.line, 1, 'should point to the first line');
             assert.strictEqual(error.column, 9, 'should point to the 9th character');
         });

--- a/test/test.js
+++ b/test/test.js
@@ -66,6 +66,9 @@ describe('plugin', function() {
             assert.lengthOf(errors, 1, 'should return one error');
 
             var error = errors[0];
+            assert.strictEqual(error.ruleId, '0', 'should have a string ID');
+            assert.strictEqual(error.severity, 2, 'should have a numeric severity');
+            assert.strictEqual(error.message, 'Property keys must be doublequoted', 'should have a message');
             assert.strictEqual(error.line, 1, 'should point to first line');
             assert.strictEqual(error.column, 2, 'should point to second character');
         });


### PR DESCRIPTION
ESLint [expects](https://github.com/eslint/eslint/blob/c0df9febb7c7e045ababc10b88dbcbb3f28c724c/lib/rules.js#L67-L75) all `ruleId`s to be strings, while `error.code` is a number.

This is causing problems elsewhere in the ESLint ecosystem: https://github.com/AtomLinter/linter-eslint/issues/1240

Note: These `ruleId`s **should** be following the [Rule Naming Conventions](https://eslint.org/docs/developer-guide/working-with-rules#rule-naming-conventions), since you aren't actually implementing these rules yourself though you would need some sort of mapping from the `error.code` to a valid name. This PR is just a basic fix to get this plugin to stop throwing errors elsewhere.