### PR TITLE
Fix running tests against the correct versions of ESLint

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,7 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run test
+    - run: npm run integration ci 7 8 # eslint versions
     - run: npm run integration test 7 8 # eslint versions
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/test/integration-across-eslint-majors.sh
+++ b/test/integration-across-eslint-majors.sh
@@ -4,7 +4,7 @@ cmd="$1"
 shift
 
 case "$cmd" in
-  test|install);;
+  test|install|ci);;
   *)
     echo "Unknown integration subcommand $cmd"
     exit 2


### PR DESCRIPTION
When I was looking at the logs of the integration runs, I noticed that the ESLint version was always 8.0.0, even for the different directories.

I realised that the `npm ci` had not been run, so ESLint was never installed for those sub-directories and so the tests are defaulting to the ESLint at the top-level directory.

This adds a `ci` option and adds it to the github actions.