### PR TITLE
Create rule schema to support "allowComments"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,8 +29,8 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run test
-    - run: npm run integration ci 7-legacy 8-legacy 8 # eslint versions
-    - run: npm run integration test 7-legacy 8-legacy 8 # eslint versions
+    - run: npm run integration ci 7-legacy 8-legacy 8 9 # eslint versions
+    - run: npm run integration test 7-legacy 8-legacy 8 9 # eslint versions
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,25 @@ const reportComment = (errorName, context) => {
     }, fileComments[context.getFilename()]);
 };
 
+const ruleSchema = [
+    {
+        anyOf: [
+            {
+                enum: ['allowComments'],
+            },
+            {
+                type: 'object',
+                properties: {
+                    allowComments: {type: 'boolean'},
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+];
+
 const makeRule = (errorName, reporters) => ({
+    meta: {schema: ruleSchema},
     create(context) {
         return {
             Program() {


### PR DESCRIPTION
eslint v9 made schema mandatory for options supported by rules:
https://eslint.org/docs/latest/extend/custom-rules#options-schemas

Previously we didn't use the meta object on the rules so now we create the meta object and populate the `schema` property.

Thanks to @BePo65 for providing context, docs and the schema itself.