### PR TITLE
Add unit tests for rules to bring up test coverage

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -223,7 +223,8 @@ function validateFile(filename, expectations = {}) {
 }
 
 describe('Rules', function () {
-    this.slow(4000);
+    this.slow(3000);
+    this.timeout(5000);
     it('validate correct json', function () {
         validateFile('good-json', {errorCount: 0, warningCount: 0});
     });
@@ -247,7 +248,8 @@ describe('Rules', function () {
 });
 
 describe('Rules with config', function () {
-    this.slow(4000);
+    this.slow(3000);
+    this.timeout(5000);
     describe('recommended', function () {
         it('detect many infringements in messy json', function () {
             validateFile('whole-mess', {


### PR DESCRIPTION
After pr #87 (or even before) test coverage was quite low, as only the processor was tested.

So I copied parts of the integration tests to bring up test coverage. These tests are quite slow (but there are only 9 tests).
Unluckily I was not able to find a configuration for the eslint ruleTester that accepted a processor option. So I stayed with the code from the integration test.

Perhaps things will get better, if the ides from issue #85 will be implemented.