### PR TITLE
Fix README.md: description of using this plugin with flat config file has too many curly brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It comes in two flavor: one strict (`recommended`) and one allowing comments `re
 
 
 ```js
-import chaiExpectPlugin from 'eslint-plugin-chai-expect';
+import json from 'eslint-plugin-json';
 
 export default [
   {

--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ It comes in two flavor: one strict (`recommended`) and one allowing comments `re
 
 
 ```js
-{
-    export default [
-      {
-        files: ["**/*.json"],
-        ...json.configs["recommended"],
-    ];
-}
+import chaiExpectPlugin from 'eslint-plugin-chai-expect';
+
+export default [
+  {
+    files: ["**/*.json"],
+    ...json.configs["recommended"]
+  }
+];
 ```
 
 ### Basic configuration (Legacy ESLint Format)


### PR DESCRIPTION
The description of using this plugin in an environment with flat eslint config files had too many curly brackets.